### PR TITLE
Fix scanner parsing subqueries in FROM

### DIFF
--- a/src/scanner.ts
+++ b/src/scanner.ts
@@ -76,7 +76,9 @@ export default class Scanner {
     }
 
     push(argument) {
-        this.tree[this.rootToken].push(argument);
+        if (Array.isArray(this.tree[this.rootToken])) {
+            this.tree[this.rootToken].push(argument);
+        }
         this.expectedNext = false;
     }
 


### PR DESCRIPTION
I'm not using this DS directly for panel rendering but for querying variables only. 

However, while I was testing the fix for https://github.com/Vertamedia/clickhouse-grafana/issues/109 I noticed that when it tries to push into `this.tree[this.rootToken]` where `this.rootToken` is `'from'`, for queries with `... FROM (subquery)` the value of `this.tree[this.rootToken]` is not an array but tree object for that subquery.  
I suppose it should ignore the push then.