### PR TITLE
Take into account complex table and column names (complement #101)

### DIFF
--- a/spec/sql_query_specs.jest.ts
+++ b/spec/sql_query_specs.jest.ts
@@ -45,3 +45,21 @@ describe("$unescape", () => {
         expect(SqlQuery.unescape(query)).toBe(expQuery);
     });
 });
+
+describe("Identifiers back-quoting", () => {
+    it("Standard identifier - untouched", () => {
+        expect(SqlQuery.escapeIdentifier("My_Identifier_33")).toBe("My_Identifier_33");
+    });
+    it("Begining with number", () => {
+        expect(SqlQuery.escapeIdentifier("1nfoVista")).toBe("`1nfoVista`");
+    });
+    it("Containing spaces", () => {
+        expect(SqlQuery.escapeIdentifier("My Identifier")).toBe("`My Identifier`");
+    });
+    it("Containing special characters", () => {
+        expect(SqlQuery.escapeIdentifier("My/Identifier")).toBe("`My/Identifier`");
+    });
+    it("Containing back-quote", () => {
+        expect(SqlQuery.escapeIdentifier("My`Bad`Identifier")).toBe("`My``Bad``Identifier`");
+    });
+});

--- a/src/sql_query.ts
+++ b/src/sql_query.ts
@@ -100,9 +100,9 @@ export default class SqlQuery {
         this.target.rawQuery = query
             .replace(/\$timeSeries/g, SqlQuery.getTimeSeries(dateTimeType))
             .replace(/\$timeFilter/g, timeFilter)
-            .replace(/\$table/g, this.target.database + '.' + this.target.table)
-            .replace(/\$dateCol/g, this.target.dateColDataType)
-            .replace(/\$dateTimeCol/g, this.target.dateTimeColDataType)
+            .replace(/\$table/g, SqlQuery.escapeIdentifier(this.target.database) + '.' + SqlQuery.escapeIdentifier(this.target.table))
+            .replace(/\$dateCol/g, SqlQuery.escapeIdentifier(this.target.dateColDataType))
+            .replace(/\$dateTimeCol/g, SqlQuery.escapeIdentifier(this.target.dateTimeColDataType))
             .replace(/\$interval/g, interval)
             .replace(/\$adhoc/g, renderedAdHocCondition)
             .replace(/(?:\r\n|\r|\n)/g, ' ');
@@ -113,6 +113,14 @@ export default class SqlQuery {
         this.target.rawQuery = SqlQuery.replaceTimeFilters(this.target.rawQuery, this.options.range, dateTimeType, round);
 
         return this.target.rawQuery;
+    }    
+    
+    static escapeIdentifier(identifier: string): string {
+        if (/^[a-zA-Z_][0-9a-zA-Z_]*$/.test(identifier)) {
+            return identifier;
+        } else {
+            return '`' + identifier.replace(/`/g, '``') + '`';
+        }
     }
 
     static replaceTimeFilters(query: string, range: TimeRange, dateTimeType : string = 'DATETIME', round?: number): string {


### PR DESCRIPTION
Hello,
I propose a more complete fix for the issue with complex names, where the name must be back-quoted in SQL query (Cf pull request #101). This fix includes:
- back-quote only when necessary
- takes into account database and table name, plus two timestamp column names (dateCol and dateTimeCol)
- takes into account one or several potential back-quote characters in name
- includes unitary tests