### PR TITLE
Fix AST parser regexp error for backslash-single quote \'

### DIFF
--- a/src/scanner.ts
+++ b/src/scanner.ts
@@ -242,7 +242,7 @@ let wsRe = "\\s+",
     intRe = "\\d+",
     powerIntRe = "\\d+e\\d+",
     floatRe = "\\d+\\.\\d*|\\d*\\.\\d+|\\d+[eE][-+]\\d+",
-    stringRe = "('[^']*')|(`[^`]*`)",
+    stringRe = "('(?:[^'\\\\]|\\\\.)*')|(`[^`]*`)",
     binaryOpRe = "=>|\\|\\||>=|<=|==|!=|<>|->|[-+/%*=<>\\.!]",
     statementRe = "\\b(select|from|where|having|order by|group by|limit|format|prewhere|union all)\\b",
     joinsRe = "(any inner join|any left join|all inner join|all left join" +


### PR DESCRIPTION
The AST parser does not take into account the presence of backslashed single quotes, and the parsed token is truncated on them. Tested on plugin version 1.8.1 and Grafana 6.1.4.

Simple query:
`SELECT arrayJoin(arrayMap(x -> MACStringToNum(x), splitByChar(',', replaceRegexpAll(replaceRegexpAll(toString(['CC:09:C8:08:50:2B','00:1A:79:06:3C:93']),'[\\[\\]\' \t\n]', ''),'([A-F0-9]+)','\\1'))))`

Сhrome developer console:
`AST parser error:  cannot find next token in [\t\n]', ''), '([A-F0-9]+)', '\\1'))))]`

This patch should fix it.