### PR TITLE
alerting support need JSON format

### DIFF
--- a/datasource.go
+++ b/datasource.go
@@ -106,7 +106,7 @@ func createRequest(req *datasource.DatasourceRequest, query string) (*http.Reque
 		case "usePOST":
 			method = http.MethodPost
 			params.Del("query")
-			body = query
+			body = query+" FORMAT JSON"
 			break
 		case "defaultDatabase":
 			db, _ := v.(string)


### PR DESCRIPTION
I test the Alert but throw out error:
error:"tsdb.HandleRequest() error rpc error: code = Unknown desc = unable to parse response json: 1593511200000 3784 1816 466 1593514800000 6460 2345 836 .... : invalid character '3' after top-level value"
Grafana version 7.0.5
Clickhouse driver 2.0.1/2.0.2

The driver always sends a POST request from driver backend in TSV format, but JSON is required.
The POST/GET switch in the driver settings is ignored, only the POST request is always used for alerting queries.

This fix only changes the format for post requests, but I did not find how to fix the post / get switch