### PR TITLE
using the switch of the GET/POST method from the driver settings

### DIFF
--- a/datasource.go
+++ b/datasource.go
@@ -104,9 +104,11 @@ func createRequest(req *datasource.DatasourceRequest, query string) (*http.Reque
 	for k, v := range options {
 		switch k {
 		case "usePOST":
-			method = http.MethodPost
-			params.Del("query")
-			body = query+" FORMAT JSON"
+			if v == true {
+				method = http.MethodPost
+				params.Del("query")
+				body = query+" FORMAT JSON"
+			}
 			break
 		case "defaultDatabase":
 			db, _ := v.(string)


### PR DESCRIPTION
Alert support always sends a request only using the POST method, ignoring the data source settings.
This fix gets the GET / POST request method setting from the data source settings in the backend.