### PR TITLE
plugin.json validator fixes

### DIFF
--- a/src/plugin.json
+++ b/src/plugin.json
@@ -29,6 +29,12 @@
         "url": "https://github.com/Vertamedia/clickhouse-grafana"
       }
     ],
-    "version": "2.0.4"
+    "version": "2.0.4",
+    "updated": "2020-07-31"
+  },
+
+  "dependencies": {
+    "grafanaVersion": "6.5",
+    "plugins": []
   }
 }


### PR DESCRIPTION
according to https://github.com/grafana/grafana-plugin-repository/pull/690#issuecomment-667095265

try to fix
https://grafana-plugins-web-vgmmyppaka-lz.a.run.app/?url=Vertamedia/clickhouse-grafana@f340426c950b954dfe34a1f20f5fc0f24f7cf927

prepare to 2.0.5

Signed-off-by: Eugene Klimov <eklimov@altinity.com>