### PR TITLE
Make release 2.0.6

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,7 +1,7 @@
 [bumpversion]
 commit = True
 tag = False
-current_version = 2.0.5
+current_version = 2.0.6
 
 [bumpversion:file:package.json]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 2.0.6 (2020-08-05)
+
+## Enhancement:
+  * add "Skip comments" checkbox to query editor to pass SQL comments to server, fix https://github.com/Vertamedia/clickhouse-grafana/issues/265
+  
+## Security   
+  * rollback SQL+javascript preprocessing logic on browser side to avoid XSS scripting, sorry @fgbogdan
+
 # 2.0.5 (2020-08-01)
 
 ## Fixes:

--- a/dist/plugin.json
+++ b/dist/plugin.json
@@ -29,7 +29,7 @@
         "url": "https://github.com/Vertamedia/clickhouse-grafana"
       }
     ],
-    "version": "2.0.5",
+    "version": "2.0.6",
     "updated": "2020-07-31"
   },
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "vertamedia-clickhouse",
-    "version": "2.0.5",
+    "version": "2.0.6",
     "description": "ClickHouse datasource for Grafana",
     "scripts": {
         "build:prod": "webpack --config webpack.config.prod.js",

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -29,7 +29,7 @@
         "url": "https://github.com/Vertamedia/clickhouse-grafana"
       }
     ],
-    "version": "2.0.5",
+    "version": "2.0.6",
     "updated": "2020-07-31"
   },
 


### PR DESCRIPTION
# 2.0.6 (2020-08-05)

## Enhancement:
  * add "Skip comments" checkbox to query editor to pass SQL comments to server, fix https://github.com/Vertamedia/clickhouse-grafana/issues/265
  
## Security   
  * rollback SQL+javascript preprocessing logic on browser side to avoid XSS scripting, sorry @fgbogdan
