### PR TITLE
Fix FieldArray Nullable issue

### DIFF
--- a/pkg/response.go
+++ b/pkg/response.go
@@ -112,10 +112,9 @@ func (r *Response) toFramesWithTimeStamp(query *Query, fetchTZ FetchTZFunc, hasL
 									switch tuple := array.(type) {
 									case []interface{}:
 										tsName := ParseValue(fieldName, labelType, timeZonesMap[fieldName], tuple[0], false)
-										tsValue := ParseValue(fieldName, valueType, timeZonesMap[fieldName], tuple[1], false)
 										r.createFrameIfNotExistsAndAddPoint(
 											query, framesMap, tsName.(string), timeStampDataFieldMap, timestampFieldName, valueDataFieldMap,
-											fieldName, valueType, timestampValue, timeZonesMap, tsValue,
+											fieldName, valueType, timestampValue, timeZonesMap, tuple[1],
 										)
 
 									default:


### PR DESCRIPTION
parseFloatValue() returns pointer if value is Nullable.
In case of GroupArray value is going through the parseFloatValue() twice.
As a result it fails because reflect.ValueOf(value).Float() can proceed with pointer value.

This MR just removes one parseFloatValue() call to avoid such an issue.